### PR TITLE
#163177202 Save user token on log in

### DIFF
--- a/__tests__/actions.test.js
+++ b/__tests__/actions.test.js
@@ -47,14 +47,14 @@ describe('Redux actions', () => {
   });
 
   describe('signUp()', () => {
-    const payload = { id: 1, email: 'try@m.com', token: 'fakeToken' };
+    const payload = { user: { id: 1, email: 'try@m.com', token: 'fakeToken' } };
 
-    test('should dispatch with user payload', async () => {
+    test('should dispatch signup and get current user', async () => {
       await axiosMock.onPost().replyOnce(201, payload);
       await signUp()(dispatch);
-      expect(dispatch).toBeCalledTimes(1);
-      delete payload.token;
-      expect(dispatch).toHaveBeenCalledWith({ type: SIGN_UP, payload: { user: payload } });
+      expect(dispatch).toBeCalledTimes(2);
+      delete payload.user.token;
+      expect(dispatch).toHaveBeenCalledWith({ type: SIGN_UP, payload: { user: payload.user } });
     });
 
     test('logoutUser', () => {
@@ -82,13 +82,15 @@ describe('Redux actions', () => {
       expect(dispatch).toHaveBeenCalledWith({ type: LOG_IN, payload: { error } });
     });
 
-    test('fail to dispatch login action', async () => {
-      const payload = { token: 'fakeToken' };
+    test('dispatch login action and get current user', async () => {
+      const payload = { user: { id: 1, token: 'fakeToken' } };
       await axiosMock.onPost().replyOnce(200, payload);
 
       await login()(dispatch);
-      expect(dispatch).toHaveBeenCalledTimes(1);
-      expect(dispatch).toHaveBeenCalledWith({ type: LOG_IN, payload });
+      expect(authUtils.getToken()).toBe(payload.user.token);
+      delete payload.user.token;
+      expect(dispatch).toHaveBeenCalledTimes(2);
+      expect(dispatch).toHaveBeenCalledWith({ type: LOG_IN, payload: { user: payload.user } });
     });
   });
 });

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -9,23 +9,28 @@ export const getAllMenu = () => async (dispatch) => {
   dispatch({ type: GET_ALL_MENU, payload: data });
 };
 
-export const signUp = formData => dispatch => axios
-  .post('/auth/signup', formData)
-  .then(({ data: { token, ...user } }) => {
-    authUtils.saveToken(token);
-    dispatch({ type: SIGN_UP, payload: { user } });
-  })
-  .catch(error => dispatch({ type: SIGN_UP, payload: { error } }));
-
-export const login = credentials => async dispatch => axios
-  .post('/auth/login', credentials)
-  .then(({ data }) => dispatch({ type: LOG_IN, payload: data }))
-  .catch(error => dispatch({ type: LOG_IN, payload: { error } }));
-
 export const getCurrentUser = () => dispatch => axios
   .get('/users/me')
   .then(({ data }) => dispatch({ type: GET_CURRENT_USER, payload: data }))
   .catch(() => dispatch({ type: GET_CURRENT_USER }));
+
+export const signUp = formData => dispatch => axios
+  .post('/auth/signup', formData)
+  .then(({ data: { user: { token, ...user } } }) => {
+    authUtils.saveToken(token);
+    dispatch({ type: SIGN_UP, payload: { user } });
+    return getCurrentUser()(dispatch);
+  })
+  .catch(error => dispatch({ type: SIGN_UP, payload: { error } }));
+
+export const login = credentials => dispatch => axios
+  .post('/auth/login', credentials)
+  .then(({ data: { user: { token, ...user } } }) => {
+    authUtils.saveToken(token);
+    dispatch({ type: LOG_IN, payload: { user } });
+    return getCurrentUser()(dispatch);
+  })
+  .catch(error => dispatch({ type: LOG_IN, payload: { error } }));
 
 export const logoutUser = () => {
   authUtils.removeToken();


### PR DESCRIPTION
#### What does this PR do?
Saves generated token for a user on login in localStorage

#### Description of Task to be completed?
Have user token saved in localStorage on log in

#### How should this be manually tested?
```bash
git clone git@github.com:codeshifu/eatly-react.git

cd eatly-react

npm install

npm start

```

Visit `/login`, upon log in check dev tools `Application` panel to see token stored

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#163177202](https://www.pivotaltracker.com/story/show/163177202)

#### Screenshots (if appropriate)
N/A

#### Questions:
N/A
