### PR TITLE
feat(order): implement logic to order menu

### DIFF
--- a/__tests__/actions.test.js
+++ b/__tests__/actions.test.js
@@ -1,9 +1,9 @@
 import MockAdapter from 'axios-mock-adapter';
 import {
-  getAllMenu, signUp, getCurrentUser, logoutUser, login,
+  getAllMenu, signUp, getCurrentUser, logoutUser, login, placeOrder, getSelectedMenu,
 } from '../src/actions';
 import {
-  GET_ALL_MENU, SIGN_UP, GET_CURRENT_USER, LOG_IN,
+  GET_ALL_MENU, SIGN_UP, GET_CURRENT_USER, LOG_IN, PLACE_ORDER, GET_SELECTED_MENU,
 } from '../src/actions/types';
 import axios from '../src/utils/axiosInstance';
 import authUtils from '../src/utils/auth';
@@ -91,6 +91,43 @@ describe('Redux actions', () => {
       delete payload.user.token;
       expect(dispatch).toHaveBeenCalledTimes(2);
       expect(dispatch).toHaveBeenCalledWith({ type: LOG_IN, payload: { user: payload.user } });
+    });
+  });
+
+  describe('place order', () => {
+    test('should place order successfully', async () => {
+      axiosMock.onPost().replyOnce(200);
+
+      const isPlaced = await placeOrder()(dispatch);
+      expect(dispatch).toHaveBeenCalledTimes(1);
+      expect(dispatch).toHaveBeenCalledWith({ type: PLACE_ORDER });
+      expect(isPlaced).toBeTruthy();
+    });
+
+    test('should place order successfully', async () => {
+      axiosMock.onPost().replyOnce(500);
+
+      const isPlaced = await placeOrder()(dispatch);
+      expect(dispatch).toHaveBeenCalledTimes(0);
+      expect(isPlaced).toBeFalsy();
+    });
+  });
+
+  describe('get selected menu', () => {
+    test('should fetch a menu by id', async () => {
+      const payload = { id: 1, name: 'jollof rice' };
+      axiosMock.onGet().replyOnce(200, payload);
+      await getSelectedMenu()(dispatch);
+      expect(dispatch).toHaveBeenCalledTimes(1);
+      expect(dispatch).toHaveBeenCalledWith({ type: GET_SELECTED_MENU, payload });
+    });
+
+    test('fails to fetch a menu by id', async () => {
+      const payload = { id: 1, name: 'jollof rice' };
+      axiosMock.onGet().replyOnce(500, payload);
+      await getSelectedMenu()(dispatch);
+      expect(dispatch).toHaveBeenCalledTimes(1);
+      expect(dispatch).toHaveBeenCalledWith({ type: GET_SELECTED_MENU, payload: null });
     });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -3020,8 +3020,7 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "deep-equal": {
       "version": "1.0.1",
@@ -9699,6 +9698,15 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
+    "query-string": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.2.0.tgz",
+      "integrity": "sha512-5wupExkIt8RYL4h/FE+WTg3JHk62e6fFPWtAZA9J5IWK1PfTfKkMS93HBUHcFpeYi9KsY5pFbh+ldvEyaz5MyA==",
+      "requires": {
+        "decode-uri-component": "^0.2.0",
+        "strict-uri-encode": "^2.0.0"
+      }
+    },
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
@@ -10800,6 +10808,11 @@
         "is-fullwidth-code-point": "^2.0.0"
       }
     },
+    "slugify": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.3.4.tgz",
+      "integrity": "sha512-KP0ZYk5hJNBS8/eIjGkFDCzGQIoZ1mnfQRYS5WM3273z+fxGWXeN0fkwf2ebEweydv9tioZIHGZKoF21U07/nw=="
+    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -11319,6 +11332,11 @@
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true
+    },
+    "strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string-length": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -23,13 +23,15 @@
   "dependencies": {
     "axios": "0.18.0",
     "prop-types": "15.6.2",
+    "query-string": "6.2.0",
     "react": "16.7.0",
     "react-dom": "16.7.0",
     "react-redux": "6.0.0",
     "react-router-dom": "4.3.1",
     "redux": "4.0.1",
     "redux-form": "8.1.0",
-    "redux-thunk": "2.3.0"
+    "redux-thunk": "2.3.0",
+    "slugify": "1.3.4"
   },
   "devDependencies": {
     "@babel/core": "7.2.2",
@@ -65,6 +67,11 @@
     "webpack-merge": "4.2.1"
   },
   "jest": {
-    "setupTestFrameworkScriptFile": "<rootDir>src/utils/setupTests.js"
+    "setupTestFrameworkScriptFile": "<rootDir>src/utils/setupTests.js",
+    "collectCoverageFrom": [
+      "**/*.{js,jsx}",
+      "!**/node_modules/**",
+      "!**/vendor/**"
+    ]
   }
 }

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -3,17 +3,31 @@ import authUtils from '../utils/auth';
 import cartUtils from '../utils/cart';
 import {
   GET_ALL_MENU,
+  GET_SELECTED_MENU,
   SIGN_UP,
   LOG_IN,
   GET_CURRENT_USER,
   LOG_OUT,
   ADD_TO_CART,
   CART_ITEMS_COUNT,
+  PLACE_ORDER,
 } from './types';
 
 export const getAllMenu = () => dispatch => axios('/menu')
-  .then(({ data }) => dispatch({ type: GET_ALL_MENU, payload: data.reverse() }))
-  .catch(() => dispatch({ type: GET_ALL_MENU, payload: [] }));
+  .then(({ data }) => {
+    dispatch({ type: GET_ALL_MENU, payload: data.reverse() });
+  })
+  .catch(() => {
+    dispatch({ type: GET_ALL_MENU, payload: [] });
+  });
+
+export const getSelectedMenu = id => dispatch => axios(`/menu/${id}`)
+  .then(({ data }) => {
+    dispatch({ type: GET_SELECTED_MENU, payload: data });
+  })
+  .catch(() => {
+    dispatch({ type: GET_SELECTED_MENU, payload: null });
+  });
 
 export const getCurrentUser = () => dispatch => axios
   .get('/users/me')
@@ -66,3 +80,9 @@ export const addToCart = ({ description, ...menu }) => (dispatch) => {
   dispatch({ type: ADD_TO_CART, payload: cartUtils.getCartItem(newMenu.id) });
   dispatch(getCartItemsCount());
 };
+
+export const placeOrder = data => dispatch => axios.post('/orders', data)
+  .then(() => {
+    dispatch({ type: PLACE_ORDER });
+    return true;
+  }).catch(() => false);

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -1,4 +1,5 @@
 export const GET_ALL_MENU = 'GET_ALL_MENU';
+export const GET_SELECTED_MENU = 'GET_SELECTED_MENU';
 
 export const LOG_IN = 'LOG_IN';
 export const SIGN_UP = 'SIGN_UP';
@@ -8,3 +9,5 @@ export const GET_CURRENT_USER = 'GET_CURRENT_USER';
 
 export const ADD_TO_CART = 'ADD_TO_CART';
 export const CART_ITEMS_COUNT = 'CART_ITEMS_COUNT';
+
+export const PLACE_ORDER = 'PLACE_ORDER';

--- a/src/assets/sass/_base.scss
+++ b/src/assets/sass/_base.scss
@@ -127,13 +127,13 @@ body {
 }
 .main {
   background: #fff;
-  min-height: 95vh;
+  min-height: 100vh;
   padding: 7.8rem 1.6rem;
   position: relative;
 }
 
 a {
-  color: #777777;
+  color: #62A2DC;
 }
 .btn {
   font-size: 1.6rem;
@@ -224,7 +224,7 @@ a {
   background-color: #d32f2f;
 }
 .modal,
-.loader {
+.processing {
   position: fixed;
   z-index: 100;
   top: 0;
@@ -232,11 +232,20 @@ a {
   right: 0;
   bottom: 0;
   display: none;
-  background: rgba(0, 0, 0, 0.4);
   justify-content: center;
   align-items: center;
 }
+.processing {
+  flex-direction: column;
+  padding-bottom: 10rem;
+  margin-top: 5.6rem;
+
+  &>*{
+    margin-bottom: 0.8rem;
+  }
+}
 .modal {
+  background: rgba(0, 0, 0, 0.4);
   padding: 1.6rem;
 }
 .modal-content {
@@ -252,9 +261,15 @@ a {
 .modal-content__btns {
   text-align: right;
 }
+.modal-content__btns > *:not(:last-child) {
+  margin-right: 0.8rem;
+}
 .hint {
   font-size: 1.3rem;
   margin: 0.5rem;
+}
+.show {
+  display: flex;
 }
 @-webkit-keyframes spin {
   to {
@@ -267,6 +282,7 @@ a {
     stroke-dashoffset: -264;
   }
 }
+
 .spinner circle {
   fill: none;
   stroke: slategray;

--- a/src/components/auth/login/Login.js
+++ b/src/components/auth/login/Login.js
@@ -4,12 +4,19 @@ import { Redirect } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import LoginForm from './LoginForm';
 
-const Login = ({ user }) => <div>{!user ? <LoginForm /> : <Redirect to="/" />}</div>;
+const Login = ({ user, location }) => {
+  const { from } = location.state || { from: { pathname: '/' } };
+  return <div>{!user ? <LoginForm /> : <Redirect to={from} />}</div>;
+};
 
 Login.defaultProps = {
-  user: null,
+  user: {},
+  location: {},
 };
+
 Login.propTypes = {
   user: PropTypes.oneOfType([PropTypes.object]),
+  location: PropTypes.oneOfType([PropTypes.object]),
 };
+
 export default connect(({ auth }) => ({ user: auth.user || null }))(Login);

--- a/src/components/auth/login/Login.test.js
+++ b/src/components/auth/login/Login.test.js
@@ -22,6 +22,7 @@ describe('Submit login form', () => {
   });
 
   afterEach(axiosMock.reset);
+  afterAll(axiosMock.restore);
 
   const fillSubmitForm = () => {
     fireEvent.change(emailField, { target: { value: 'johndoe@mail.com' } });

--- a/src/components/menu/Menu.js
+++ b/src/components/menu/Menu.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
+import slugify from 'slugify';
 import Button from '../presentation/Button';
 import { addToCart } from '../../actions';
 
@@ -12,7 +14,9 @@ class Menu extends Component {
 
   render() {
     const { menu } = this.props;
-    const { name, imgurl, price } = menu;
+    const {
+      id, name, imgurl, price,
+    } = menu;
     return (
       <section data-testid="menu" className="menu">
         <div className="menu__img">
@@ -23,7 +27,9 @@ class Menu extends Component {
         </h3>
         <h4 className="menu__price">{`$${price}`}</h4>
         <div className="menu__btns">
-          <Button classes="btn-default" title="Buy now" />
+          <Link className="btn btn-default" to={`/order/${slugify(name, { lower: true })}?id=${id}`}>
+            Buy now
+          </Link>
           <Button handleClick={() => this.addToCart(menu)} classes="btn-default" title="Add item" />
         </div>
       </section>

--- a/src/components/menu/Menu.test.js
+++ b/src/components/menu/Menu.test.js
@@ -1,5 +1,7 @@
 import React from 'react';
-import { render, fireEvent } from 'react-testing-library';
+import { fireEvent } from 'react-testing-library';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
 import Menu from './Menu';
 import { renderWithRedux } from '../../utils';
 
@@ -11,14 +13,16 @@ describe('<Menu />', () => {
   };
 
   let component = {};
-
+  const history = createMemoryHistory({ initialEntries: ['/'] });
   beforeEach(() => {
-    component = renderWithRedux(<Menu menu={props} />);
+    const ui = <Router history={history}><Menu menu={props} /></Router>;
+    component = renderWithRedux(ui);
   });
 
   test('renders', () => {
-    const { getByTestId } = component;
+    const { getByTestId, getByText, container } = component;
     expect(getByTestId('menu')).toBeInTheDocument();
+    expect(getByText(/rice/i)).toBeInTheDocument();
   });
 
   test('receives props and render children', () => {
@@ -33,7 +37,7 @@ describe('<Menu />', () => {
 
   test('renders composite component', () => {
     const { container } = component;
-    expect(container.querySelectorAll('button.btn.btn-default').length).toBe(2);
+    expect(container.querySelectorAll('.btn-default').length).toBe(2);
   });
 
   test('add to cart', () => {

--- a/src/components/menu/MenuList.js
+++ b/src/components/menu/MenuList.js
@@ -20,7 +20,6 @@ class MenuList extends Component {
       state: { loading },
       props: { allMenu },
     } = this;
-
     return (
       <div className="restaurant-menu">
         {loading ? (
@@ -36,7 +35,7 @@ class MenuList extends Component {
 }
 
 MenuList.defaultProps = {
-  getAllMenu: () => {},
+  getAllMenu: null,
   allMenu: [],
 };
 
@@ -45,7 +44,7 @@ MenuList.propTypes = {
   allMenu: propTypes.arrayOf(propTypes.object),
 };
 
-const mapStateToProps = ({ allMenu }) => ({ allMenu });
+const mapStateToProps = ({ menu }) => ({ allMenu: menu.all });
 
 export default connect(
   mapStateToProps,

--- a/src/components/menu/MenuList.test.js
+++ b/src/components/menu/MenuList.test.js
@@ -1,42 +1,53 @@
 import React from 'react';
-import { wait } from 'react-testing-library';
+import { waitForDomChange } from 'react-testing-library';
 import MockAdapter from 'axios-mock-adapter';
+import { createMemoryHistory } from 'history';
+import { Router } from 'react-router-dom';
 import axios from '../../utils/axiosInstance';
 import MenuList from './MenuList';
 import { renderWithRedux } from '../../utils';
 
 const axiosMock = new MockAdapter(axios, {
-  delayResponse: Math.random() * 100,
+  delayResponse: 500,
 });
-
+const history = createMemoryHistory({ initialEntries: ['/'] });
 describe('<MenuList />', () => {
-  let component;
-  let loadingElem;
-  beforeEach(() => {
-    component = renderWithRedux(<MenuList />);
-    loadingElem = component.queryByTestId('loading');
-  });
+  const withRouter = (
+    <Router history={history}>
+      <MenuList />
+    </Router>
+  );
+
+  afterEach(axiosMock.reset);
   afterAll(axiosMock.restore);
 
   test('should fetch and display restaurant menu', async () => {
-    await axiosMock.onGet('/menu').replyOnce(200, [
+    const payload = [
       {
         id: 1,
         name: 'rice',
         imgurl: 'https://pix.io/rice.jpg',
         price: 300,
       },
-    ]);
-
-    const { container } = component;
-    await wait(() => expect(loadingElem).not.toBeInTheDocument());
+      {
+        id: 2,
+        name: 'jollof',
+        imgurl: 'https://pix.io/rice.jpg',
+        price: 999,
+      },
+    ];
+    axiosMock.onGet().replyOnce(200, payload);
+    const { container, getByText, getByTestId } = renderWithRedux(withRouter);
+    const loadingElem = getByTestId('loading');
+    expect(loadingElem).toBeInTheDocument();
+    await waitForDomChange({ container });
+    expect(getByText(/jollof/i)).toBeInTheDocument();
     expect(loadingElem).not.toBeInTheDocument();
-
-    expect(container.children.length).toBe(1);
   });
 
   test('fail to fetch restaurant menu', async () => {
     await axiosMock.onGet().replyOnce(500);
-    expect(loadingElem).toBeInTheDocument();
+    const { getByTestId } = renderWithRedux(withRouter);
+    expect(getByTestId('loading')).toBeInTheDocument();
   });
 });

--- a/src/components/order/Order.js
+++ b/src/components/order/Order.js
@@ -1,0 +1,145 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import { parse } from 'query-string';
+import { Link, withRouter } from 'react-router-dom';
+import Button from '../presentation/Button';
+import { getSelectedMenu, placeOrder } from '../../actions';
+import Processing from '../presentation/Processing';
+
+class Order extends Component {
+  state = {
+    isLoading: true,
+    processing: null,
+    successful: false,
+  }
+
+  async componentDidMount() {
+    const { location, getSelectedMenu: dispatchGetSelectedMenu } = this.props;
+    const menuId = parse(location.search).id || null;
+
+    await dispatchGetSelectedMenu(menuId);
+    await this.fakeDelay(1000, () => {
+      this.setState({ isLoading: false });
+    });
+  }
+
+  fakeDelay = (time, cb) => {
+    setTimeout(() => {
+      cb();
+    }, time);
+  }
+
+  onPlaceOrder = async (menuId) => {
+    const {
+      user, location, placeOrder: dispatchPlaceOrder, history: { push },
+    } = this.props;
+    if (!user) return push('/login', { from: location });
+    this.setState({ processing: true });
+
+    const isOrdered = await dispatchPlaceOrder({ menu_id: menuId });
+
+    await this.fakeDelay(1000, () => {
+      this.setState({ processing: false });
+      this.setState({ successful: isOrdered });
+    });
+
+    return null;
+  }
+
+  renderMenu = () => {
+    const { menu } = this.props;
+    const { processing, successful, isLoading } = this.state;
+
+    if (isLoading) {
+      return (
+        <Processing processing>
+          <h3>Getting menu</h3>
+          <p>please wait...</p>
+        </Processing>
+      );
+    }
+
+    if (!menu && !isLoading) return <h3>Menu not found</h3>;
+    if (menu && processing === null) {
+      return (
+        <div>
+          <h2>{menu.name}</h2>
+          <h3>{menu.price}</h3>
+          <div className="input-group">
+            <Button
+              handleClick={() => this.onPlaceOrder(menu.id)}
+              classes="btn-danger"
+              title="Confirm order"
+            />
+          </div>
+        </div>
+      );
+    }
+
+    if (processing) {
+      return (
+        <Processing processing>
+          <h1>Placing your order</h1>
+          <p>please wait...</p>
+        </Processing>
+      );
+    }
+
+    if (!processing && !successful) {
+      return (
+        <Processing>
+          <h1>An error occurred while placing your order</h1>
+          <p>
+            Please try again later.
+            {' '}
+            <Link to="/">Go Back</Link>
+          </p>
+        </Processing>
+      );
+    }
+
+    return (
+      <Processing>
+        <h1>Order placed successfully</h1>
+        <p>
+          Click
+          {' '}
+          <Link to="/order/history">here</Link>
+          {' '}
+          to view your order history.
+        </p>
+      </Processing>
+    );
+  }
+
+  render() {
+    return (
+      <div>
+        { this.renderMenu() }
+      </div>
+    );
+  }
+}
+
+Order.defaultProps = {
+  user: null,
+  location: null,
+  history: null,
+  menu: null,
+  getSelectedMenu: null,
+  placeOrder: null,
+};
+
+Order.propTypes = {
+  user: PropTypes.oneOfType([PropTypes.object]),
+  location: PropTypes.oneOfType([PropTypes.object]),
+  history: PropTypes.oneOfType([PropTypes.object]),
+  menu: PropTypes.oneOfType([PropTypes.object]),
+  getSelectedMenu: PropTypes.func,
+  placeOrder: PropTypes.func,
+};
+
+const mapStateToProps = ({ auth, menu }) => ({ user: auth.user || null, menu: menu.selected });
+
+export default connect(mapStateToProps, { getSelectedMenu, placeOrder })(withRouter(Order));

--- a/src/components/order/Order.test.js
+++ b/src/components/order/Order.test.js
@@ -1,0 +1,95 @@
+import React from 'react';
+import { waitForDomChange, fireEvent } from 'react-testing-library';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
+import MockAdapter from 'axios-mock-adapter';
+import axios from '../../utils/axiosInstance';
+import Order from './Order';
+import { renderWithRedux } from '../../utils';
+
+const axiosMock = new MockAdapter(axios, {
+  delayResponse: 500,
+});
+const history = createMemoryHistory({ initialEntries: ['/order/jollof-rice?id=2'] });
+history.push = jest.fn();
+
+describe('<Order />', () => {
+  let ui;
+  const initialState = { initialState: { auth: { user: { id: 3 } } } };
+
+  beforeEach(() => {
+    ui = (
+      <Router history={history}>
+        <Order />
+      </Router>
+    );
+  });
+  afterEach(() => {
+    history.push.mockReset();
+    axiosMock.reset();
+  });
+  afterAll(axiosMock.restore);
+
+  test('show loading when component first render', () => {
+    const { getByText } = renderWithRedux(ui);
+    expect(getByText(/getting menu/i)).toBeInTheDocument();
+    expect(getByText(/please wait.../i)).toBeInTheDocument();
+  });
+
+  test('fails to get menu', async () => {
+    axiosMock.onGet().replyOnce(500, null);
+    const { getByText, container } = renderWithRedux(ui);
+    await waitForDomChange({ container });
+    expect(getByText(/menu not found/i)).toBeInTheDocument();
+  });
+
+  test('gets menu and display on page', async () => {
+    axiosMock.onGet().replyOnce(200, { name: 'jollof', price: 999, id: 2 });
+    const { container } = renderWithRedux(ui);
+    await waitForDomChange({ container });
+    const confirmOrderBtn = container.querySelector('button.btn');
+    expect(confirmOrderBtn.textContent).toEqual('Confirm order');
+    expect(confirmOrderBtn).toBeInTheDocument();
+  });
+
+  test('redirect to login when confirming order w/o auth', async () => {
+    axiosMock.onGet().replyOnce(200, { name: 'jollof', price: 999, id: 2 });
+    const { container } = renderWithRedux(ui);
+    await waitForDomChange({ container });
+    const confirmOrderBtn = container.querySelector('button.btn');
+
+    fireEvent.click(confirmOrderBtn);
+    expect(history.push).toHaveBeenCalledTimes(1);
+  });
+
+  test('should fail to process order', async () => {
+    axiosMock.onGet().replyOnce(200, { name: 'jollof', price: 999, id: 2 });
+    const { container, getByText } = renderWithRedux(ui, initialState);
+
+    await waitForDomChange({ container });
+    const confirmOrderBtn = container.querySelector('button.btn');
+
+    axiosMock.onPost().replyOnce(500);
+    fireEvent.click(confirmOrderBtn);
+    expect(getByText(/placing your order/i)).toBeInTheDocument();
+    expect(history.push).toHaveBeenCalledTimes(0);
+
+    await waitForDomChange({ container });
+    expect(getByText(/An error occurred while placing your order/i)).toBeInTheDocument();
+  });
+
+  test('place order successfully', async () => {
+    axiosMock.onGet().replyOnce(200, { name: 'jollof', price: 999, id: 2 });
+    const { container, getByText } = renderWithRedux(ui, initialState);
+    await waitForDomChange({ container });
+    const confirmOrderBtn = container.querySelector('button.btn');
+
+    axiosMock.onPost().replyOnce(200);
+    fireEvent.click(confirmOrderBtn);
+    expect(getByText(/placing your order/i)).toBeInTheDocument();
+    expect(history.push).toHaveBeenCalledTimes(0);
+
+    await waitForDomChange({ container });
+    expect(getByText(/order placed successfully/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/presentation/Processing.js
+++ b/src/components/presentation/Processing.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Spinner from './Spinner';
+
+const Processing = ({ children, processing }) => (
+  <div className="processing show">
+    { processing && <Spinner />}
+    {children}
+  </div>
+);
+
+Processing.defaultProps = {
+  processing: false,
+  children: null,
+};
+
+Processing.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]), // https://stackoverflow.com/a/42122662
+  processing: PropTypes.bool,
+};
+
+export default Processing;

--- a/src/components/presentation/Spinner.js
+++ b/src/components/presentation/Spinner.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const Spinner = () => (
+  <div className="loader show">
+    <svg className="spinner" viewBox="0 0 100 100" width="20" height="20">
+      <circle cx="50" cy="50" r="42" transform="rotate(-90,50,50)" />
+    </svg>
+  </div>
+);
+
+export default Spinner;

--- a/src/components/route/index.jsx
+++ b/src/components/route/index.jsx
@@ -7,6 +7,7 @@ import Navbar from '../presentation/Navbar';
 import Login from '../auth/login/Login';
 import Signup from '../auth/signup/Signup';
 import { getCurrentUser, getCartItemsCount } from '../../actions';
+import Order from '../order/Order';
 
 const NoMatch = () => <div>404 not found</div>;
 
@@ -28,6 +29,7 @@ class AppRouter extends Component {
           <main className="main">
             <Switch>
               <Route path="/" exact component={App} />
+              <Route path="/order/:menu" component={Order} />
               <Route path="/login" exact component={Login} />
               <Route path="/register" exact component={Signup} />
               <Route component={NoMatch} />
@@ -40,8 +42,8 @@ class AppRouter extends Component {
 }
 
 AppRouter.defaultProps = {
-  getCurrentUser: () => {},
-  getCartItemsCount: () => {},
+  getCurrentUser: null,
+  getCartItemsCount: null,
 };
 
 AppRouter.propTypes = {

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -6,7 +6,7 @@ import cartReducer from './cart';
 
 export default combineReducers({
   form: formReducer,
-  allMenu: menuReducer,
+  menu: menuReducer,
   auth: authReducer,
   cart: cartReducer,
 });

--- a/src/reducers/menu.js
+++ b/src/reducers/menu.js
@@ -1,14 +1,16 @@
-import { GET_ALL_MENU } from '../actions/types';
+import { GET_ALL_MENU, GET_SELECTED_MENU } from '../actions/types';
 
-const initialState = [];
+const initialState = { all: [], selected: null };
 
 export default (state = initialState, action) => {
   const { type, payload } = action;
 
   switch (type) {
     case GET_ALL_MENU:
-      return [...payload];
+      return { ...state, all: payload };
+    case GET_SELECTED_MENU:
+      return { ...state, selected: payload };
     default:
-      return [...state];
+      return { ...state };
   }
 };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -9,7 +9,7 @@ import reducers from '../reducers';
 
 export const renderWithRedux = (
   ui,
-  { store = createStore(reducers, applyMiddleware(thunk)) } = {},
+  { initialState, store = createStore(reducers, initialState, applyMiddleware(thunk)) } = {},
 ) => ({
   ...render(<Provider store={store}>{ui}</Provider>),
   store,


### PR DESCRIPTION
#### What does this PR do?
Implements logic for ordering a restaurant menu by customers/users

#### Description of Task to be completed?
Authenticated users should be able to order restaurant menu

#### How should this be manually tested?
```bash
git clone git@githu.com:codeshifu/eatly-react.git

cd eatly-react

npm install

npm start
```

- Login via `/login`
- Click **buy now** button on a menu on the homepage `/`
- Click on **order now** button to place your order

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#162825756](https://www.pivotaltracker.com/story/show/162825756)

#### Screenshots (if appropriate)
<img width="611" alt="screen shot 2019-01-22 at 9 19 06 am" src="https://user-images.githubusercontent.com/5154605/51521393-cee1b600-1e26-11e9-8981-ac8dd54cff6d.png">

#### Questions:
N/A