### PR TITLE
#162825744 Admin view restaurant menu

### DIFF
--- a/__tests__/actions.test.js
+++ b/__tests__/actions.test.js
@@ -3,7 +3,7 @@ import {
   getAllMenu, signUp, getCurrentUser, logoutUser, login, placeOrder, getSelectedMenu,
 } from '../src/actions';
 import {
-  GET_ALL_MENU, GET_CURRENT_USER, PLACE_ORDER, GET_SELECTED_MENU, AUTHENTICATE,
+  GET_ALL_MENU, PLACE_ORDER, GET_SELECTED_MENU, AUTHENTICATE,
 } from '../src/actions/types';
 import axios from '../src/utils/axiosInstance';
 import authUtils from '../src/utils/auth';
@@ -41,18 +41,18 @@ describe('Redux actions', () => {
     });
   });
 
-  test('getCurrentUser', async () => {
+  test('getCurrentUser pass', async () => {
     await axiosMock.onGet().replyOnce(200, {});
     await getCurrentUser()(dispatch);
     expect(dispatch).toHaveBeenCalledTimes(1);
-    expect(dispatch).toHaveBeenCalledWith({ type: GET_CURRENT_USER, payload: {} });
+    expect(dispatch).toHaveBeenCalledWith({ type: AUTHENTICATE, payload: { user: { } } });
   });
 
-  test('getCurrentUser', async () => {
+  test('getCurrentUser fails', async () => {
     await axiosMock.onGet().replyOnce(500);
     await getCurrentUser()(dispatch);
     expect(dispatch).toHaveBeenCalledTimes(1);
-    expect(dispatch).toHaveBeenCalledWith({ type: GET_CURRENT_USER });
+    expect(dispatch).toHaveBeenCalledWith({ type: AUTHENTICATE });
   });
 
   describe('signUp()', () => {
@@ -63,7 +63,9 @@ describe('Redux actions', () => {
       await signUp()(dispatch);
       expect(dispatch).toBeCalledTimes(2);
       delete payload.user.token;
-      expect(dispatch).toHaveBeenCalledWith({ type: AUTHENTICATE, payload: { user: payload.user } });
+      expect(dispatch).toHaveBeenCalledWith(
+        { type: AUTHENTICATE, payload: { user: payload.user } },
+      );
     });
 
     test('logoutUser', () => {

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -5,7 +5,6 @@ import {
   GET_ALL_MENU,
   GET_SELECTED_MENU,
   AUTHENTICATE,
-  GET_CURRENT_USER,
   LOG_OUT,
   ADD_TO_CART,
   CART_ITEMS_COUNT,
@@ -27,8 +26,8 @@ export const getSelectedMenu = id => dispatch => axios(`/menu/${id}`)
 
 export const getCurrentUser = () => dispatch => axios
   .get('/users/me')
-  .then(({ data }) => dispatch({ type: GET_CURRENT_USER, payload: data }))
-  .catch(() => dispatch({ type: GET_CURRENT_USER }));
+  .then(({ data }) => dispatch({ type: AUTHENTICATE, payload: { user: data } }))
+  .catch(() => dispatch({ type: AUTHENTICATE }));
 
 export const signUp = formData => dispatch => axios
   .post('/auth/signup', formData)

--- a/src/components/menu/Menu.js
+++ b/src/components/menu/Menu.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
@@ -12,10 +12,34 @@ class Menu extends Component {
     dispatchAddToCart(menu);
   };
 
+  renderButtons = () => {
+    const { user, menu } = this.props;
+    const { name, id } = menu;
+    if (user && user.is_admin) {
+      return (
+        <Fragment>
+          <Link className="btn btn-default" to={`/menu/edit?name=${slugify(name, { lower: true })}&id=${id}`}>
+            Edit
+          </Link>
+          <Button handleClick={() => {}} classes="btn-default" title="Delete" />
+        </Fragment>
+      );
+    }
+
+    return (
+      <Fragment>
+        <Link className="btn btn-default" to={`/order/${slugify(name, { lower: true })}?id=${id}`}>
+            Buy now
+        </Link>
+        <Button handleClick={() => this.addToCart(menu)} classes="btn-default" title="Add item" />
+      </Fragment>
+    );
+  }
+
   render() {
     const { menu } = this.props;
     const {
-      id, name, imgurl, price,
+      name, imgurl, price,
     } = menu;
     return (
       <section data-testid="menu" className="menu">
@@ -27,10 +51,7 @@ class Menu extends Component {
         </h3>
         <h4 className="menu__price">{`$${price}`}</h4>
         <div className="menu__btns">
-          <Link className="btn btn-default" to={`/order/${slugify(name, { lower: true })}?id=${id}`}>
-            Buy now
-          </Link>
-          <Button handleClick={() => this.addToCart(menu)} classes="btn-default" title="Add item" />
+          { this.renderButtons() }
         </div>
       </section>
     );
@@ -40,14 +61,18 @@ class Menu extends Component {
 Menu.defaultProps = {
   menu: {},
   dispatchAddToCart: null,
+  user: null,
 };
 
 Menu.propTypes = {
   menu: PropTypes.oneOfType([PropTypes.object]),
   dispatchAddToCart: PropTypes.func,
+  user: PropTypes.oneOfType([PropTypes.object]),
 };
 
+const mapStateToProps = ({ auth: { user } }) => ({ user });
+
 export default connect(
-  null,
+  mapStateToProps,
   { dispatchAddToCart: addToCart },
 )(Menu);

--- a/src/components/menu/Menu.test.js
+++ b/src/components/menu/Menu.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent } from 'react-testing-library';
+import { fireEvent, waitForDomChange } from 'react-testing-library';
 import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
 import Menu from './Menu';
@@ -20,7 +20,7 @@ describe('<Menu />', () => {
   });
 
   test('renders', () => {
-    const { getByTestId, getByText, container } = component;
+    const { getByTestId, getByText } = component;
     expect(getByTestId('menu')).toBeInTheDocument();
     expect(getByText(/rice/i)).toBeInTheDocument();
   });
@@ -43,5 +43,17 @@ describe('<Menu />', () => {
   test('add to cart', () => {
     const { getByText } = component;
     fireEvent.click(getByText(/add item/i));
+  });
+
+  test('shows edit/delete button for admin', async () => {
+    const ui = (
+      <Router history={createMemoryHistory({ initialEntries: ['/'] })}>
+        <Menu menu={props} />
+      </Router>
+    );
+    const { getByText } = renderWithRedux(ui,
+      { initialState: { auth: { user: { is_admin: true } } } });
+    expect(getByText(/edit/i)).toBeInTheDocument();
+    expect(getByText(/delete/i)).toBeInTheDocument();
   });
 });

--- a/src/components/route/AppRouter.test.js
+++ b/src/components/route/AppRouter.test.js
@@ -22,7 +22,7 @@ describe('AppRouter', () => {
   );
 
   test('renders properly', async () => {
-    axiosMock.onGet().replyOnce(200);
+    axiosMock.onGet('/users/me').replyOnce(200, { id: 1 });
     const { getByText, container } = renderWithRedux(ui,
       { initialState: { auth: { user: { id: 1 }, isLoggedIn: true } } });
     const logoutButton = getByText(/logout/i);

--- a/src/reducers/auth.js
+++ b/src/reducers/auth.js
@@ -8,7 +8,7 @@ export default (state = initialState, action) => {
   const { type, payload } = action;
   switch (type) {
     case AUTHENTICATE:
-      return payload.user
+      return payload && payload.user
         ? { ...payload, isLoggedIn: true }
         : { ...state, ...payload, isLoggedIn: false };
     case LOG_OUT:


### PR DESCRIPTION
#### What does this PR do?
Dynamically change homepage content when an admin is viewing

#### Description of Task to be completed?
Have an admin view restaurant menu

#### How should this be manually tested?
```bash
git clone git@github.com:codeshifu/eatly-react.git

cd eatly-react

npm install

npm start
```

#### Any background context you want to provide?
Log in as admin to see dynamic content on homepage  `/`

#### What are the relevant pivotal tracker stories?
[#162825744](https://www.pivotaltracker.com/story/show/162825744)

#### Screenshots (if appropriate)
<img width="373" alt="screen shot 2019-01-26 at 9 46 51 am" src="https://user-images.githubusercontent.com/5154605/51784837-5e50d700-214f-11e9-9e2c-776110494114.png">

#### Questions:
N/A
