### PR TITLE
#163503584 Admin can delete a menu

### DIFF
--- a/__tests__/actions.test.js
+++ b/__tests__/actions.test.js
@@ -3,11 +3,11 @@ import {
   getAllMenu, signUp, getCurrentUser, logoutUser, login, placeOrder, getSelectedMenu,
 } from '../src/actions';
 import {
-  GET_ALL_MENU, PLACE_ORDER, GET_SELECTED_MENU, AUTHENTICATE, ADD_MENU,
+  GET_ALL_MENU, PLACE_ORDER, GET_SELECTED_MENU, AUTHENTICATE, ADD_MENU, DELETE_MENU,
 } from '../src/actions/types';
 import axios from '../src/utils/axiosInstance';
 import authUtils from '../src/utils/auth';
-import { addMenu } from '../src/actions/menu';
+import { addMenu, deleteMenu } from '../src/actions/menu';
 
 const axiosMock = new MockAdapter(axios, { delayResponse: 100 });
 const dispatch = jest.fn();
@@ -155,6 +155,19 @@ describe('Redux actions', () => {
     test('fails to add/create a menu', async () => {
       axiosMock.onPost().replyOnce(500);
       await addMenu()(dispatch);
+      expect(dispatch).toHaveBeenCalledTimes(0);
+    });
+
+    test('deletes a menu', async () => {
+      axiosMock.onDelete().replyOnce(200);
+      await deleteMenu(1)(dispatch);
+      expect(dispatch).toHaveBeenCalledTimes(1);
+      expect(dispatch).toHaveBeenCalledWith({ type: DELETE_MENU, payload: 1 });
+    });
+
+    test('error deleting a menu', async () => {
+      axiosMock.onDelete().replyOnce(500);
+      await deleteMenu(1)(dispatch);
       expect(dispatch).toHaveBeenCalledTimes(0);
     });
   });

--- a/src/actions/menu.js
+++ b/src/actions/menu.js
@@ -1,8 +1,6 @@
 import axios from '../utils/axiosInstance';
-import { ADD_MENU } from './types';
+import { ADD_MENU, DELETE_MENU } from './types';
 import toastr from '../utils/toastrInstance';
-
-export const d = () => {};
 
 export const addMenu = menu => async dispatch => axios.post('/menu', menu)
   .then(() => {
@@ -10,3 +8,9 @@ export const addMenu = menu => async dispatch => axios.post('/menu', menu)
     toastr.success('Menu added successfully.');
   })
   .catch(() => toastr.error('Failed to add menu'));
+
+export const deleteMenu = id => async dispatch => axios.delete(`/menu/${id}`)
+  .then(() => {
+    dispatch({ type: DELETE_MENU, payload: id });
+    toastr.success('Menu deleted successfully.');
+  }).catch(() => toastr.error('Failed to delete menu.'));

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -1,6 +1,7 @@
 export const GET_ALL_MENU = 'GET_ALL_MENU';
 export const GET_SELECTED_MENU = 'GET_SELECTED_MENU';
 export const ADD_MENU = 'ADD_MENU';
+export const DELETE_MENU = 'DELETE_MENU';
 
 export const AUTHENTICATE = 'AUTHENTICATE';
 export const LOG_OUT = 'LOG_OUT';

--- a/src/assets/sass/_base.scss
+++ b/src/assets/sass/_base.scss
@@ -248,6 +248,7 @@ a {
 }
 .modal {
   background: rgba(0, 0, 0, 0.4);
+  display: flex;
   padding: 1.6rem;
 }
 .modal-content {

--- a/src/assets/sass/menu.scss
+++ b/src/assets/sass/menu.scss
@@ -62,7 +62,7 @@
     border-bottom: 1px solid #f0eeee;
   }
   .menu__img {
-    height: 18rem;
+    height: 20rem;
   }
   .menu__name {
     width: auto;

--- a/src/components/menu/AddEditMenuForm.js
+++ b/src/components/menu/AddEditMenuForm.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import Input from '../presentation/Input';
 import formValidator from '../../utils/formValidator';
 import Button from '../presentation/Button';
+import Processing from '../presentation/Processing';
 
 const { _required, _minValue3, _minPrice } = formValidator;
 
@@ -12,6 +13,7 @@ const AddEditMenuForm = ({
 }) => (
   <form onSubmit={handleSubmit(values => onAddEditMenu(values, reset))}>
     <h1 className="form-title">{`${title} menu`}</h1>
+    { submitting && <Processing processing />}
     <Field
       autoFocus
       placeholder="Jollof rice"

--- a/src/components/menu/Menu.js
+++ b/src/components/menu/Menu.js
@@ -5,23 +5,56 @@ import { Link } from 'react-router-dom';
 import slugify from 'slugify';
 import Button from '../presentation/Button';
 import { addToCart } from '../../actions';
+import { deleteMenu } from '../../actions/menu';
+import Modal from '../presentation/Modal';
 
 class Menu extends Component {
+  state = {
+    modal: {
+      show: false,
+      title: 'Delete menu?',
+      message: 'This will permanently remove menu from database',
+      positiveTitle: 'Confirm',
+      negativeTitle: 'Back',
+      onNegativeClick: () => this.closeModal(),
+      onPositiveClick: () => this.handleDeleteMenu(),
+    },
+  }
+
+  closeModal = () => {
+    const { modal: modalConfig } = this.state;
+    this.setState({ modal: { ...modalConfig, show: false } });
+  }
+
+  showModal = () => {
+    const { modal: modalConfig } = this.state;
+    this.setState({ modal: { ...modalConfig, show: true } });
+  }
+
   addToCart = (menu) => {
     const { dispatchAddToCart } = this.props;
     dispatchAddToCart(menu);
   };
 
+  handleDeleteMenu = async () => {
+    const { dispatchDeleteMenu, menu: { id } } = this.props;
+    await dispatchDeleteMenu(parseInt(id, 10));
+    this.closeModal();
+  }
+
   renderButtons = () => {
     const { user, menu } = this.props;
+    const { modal } = this.state;
     const { name, id } = menu;
+
     if (user && user.is_admin) {
       return (
         <Fragment>
+          { modal.show && <Modal config={modal} />}
           <Link className="btn btn-default" to={`/menu/edit?name=${slugify(name, { lower: true })}&id=${id}`}>
             Edit
           </Link>
-          <Button handleClick={() => {}} classes="btn-default" title="Delete" />
+          <Button handleClick={() => this.showModal()} classes="btn-default" title="Delete" />
         </Fragment>
       );
     }
@@ -61,12 +94,14 @@ class Menu extends Component {
 Menu.defaultProps = {
   menu: {},
   dispatchAddToCart: null,
+  dispatchDeleteMenu: null,
   user: null,
 };
 
 Menu.propTypes = {
   menu: PropTypes.oneOfType([PropTypes.object]),
   dispatchAddToCart: PropTypes.func,
+  dispatchDeleteMenu: PropTypes.func,
   user: PropTypes.oneOfType([PropTypes.object]),
 };
 
@@ -74,5 +109,8 @@ const mapStateToProps = ({ auth: { user } }) => ({ user });
 
 export default connect(
   mapStateToProps,
-  { dispatchAddToCart: addToCart },
+  {
+    dispatchAddToCart: addToCart,
+    dispatchDeleteMenu: deleteMenu,
+  },
 )(Menu);

--- a/src/components/menu/Menu.test.js
+++ b/src/components/menu/Menu.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, waitForDomChange } from 'react-testing-library';
+import { fireEvent } from 'react-testing-library';
 import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
 import Menu from './Menu';
@@ -11,11 +11,11 @@ describe('<Menu />', () => {
     imgurl: 'https://pix.io/rice.jpg',
     price: 300,
   };
-
+  let ui;
   let component = {};
   const history = createMemoryHistory({ initialEntries: ['/'] });
   beforeEach(() => {
-    const ui = <Router history={history}><Menu menu={props} /></Router>;
+    ui = <Router history={history}><Menu menu={props} /></Router>;
     component = renderWithRedux(ui);
   });
 
@@ -46,14 +46,16 @@ describe('<Menu />', () => {
   });
 
   test('shows edit/delete button for admin', async () => {
-    const ui = (
-      <Router history={createMemoryHistory({ initialEntries: ['/'] })}>
-        <Menu menu={props} />
-      </Router>
-    );
     const { getByText } = renderWithRedux(ui,
       { initialState: { auth: { user: { is_admin: true } } } });
     expect(getByText(/edit/i)).toBeInTheDocument();
     expect(getByText(/delete/i)).toBeInTheDocument();
+  });
+
+  test('clicking on delete button toggles modal', () => {
+    const { getByText } = renderWithRedux(ui, { initialState: { auth: { user: { is_admin: true } } } });
+    fireEvent.click(getByText(/delete/i));
+    expect(getByText(/confirm/i)).toBeInTheDocument();
+    fireEvent.click(getByText(/back/i));
   });
 });

--- a/src/components/presentation/Modal.js
+++ b/src/components/presentation/Modal.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Modal = (props) => {
+  const {
+    config: {
+      title, message, onNegativeClick, onPositiveClick,
+      negativeTitle = 'Cancel', positiveTitle,
+    },
+  } = props;
+
+  return (
+    <div className="modal">
+      <div className="modal-content">
+        <h3 className="modal-content__title">{title}</h3>
+        <p className="modal-content__msg">{message}</p>
+        <div className="modal-content__btns">
+          <button onClick={onNegativeClick} className="negative btn btn-default">{negativeTitle}</button>
+          <button onClick={onPositiveClick} className="positive btn btn-danger">{positiveTitle}</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+Modal.propTypes = {
+  config: PropTypes.oneOfType([PropTypes.object]).isRequired,
+};
+
+export default Modal;

--- a/src/components/presentation/Modal.test.js
+++ b/src/components/presentation/Modal.test.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { render } from 'react-testing-library';
+import Modal from './Modal';
+
+test('should render w/ default negative button title', () => {
+  const prop = { };
+  const { getByText } = render(<Modal config={prop} />);
+  expect(getByText(/cancel/i)).toBeInTheDocument();
+});

--- a/src/reducers/menu.js
+++ b/src/reducers/menu.js
@@ -1,4 +1,4 @@
-import { GET_ALL_MENU, GET_SELECTED_MENU } from '../actions/types';
+import { GET_ALL_MENU, GET_SELECTED_MENU, DELETE_MENU } from '../actions/types';
 
 const initialState = { all: [], selected: null };
 
@@ -10,6 +10,8 @@ export default (state = initialState, action) => {
       return { ...state, all: payload };
     case GET_SELECTED_MENU:
       return { ...state, selected: payload };
+    case DELETE_MENU:
+      return { ...state, all: state.all.filter(menu => menu.id !== payload) };
     default:
       return { ...state };
   }


### PR DESCRIPTION
#### What does this PR do?
Implements logic for admin to be able to delete a restaurant menu by clicking on the delete button

#### Description of Task to be completed?
Have the delete button working for admin user

#### How should this be manually tested?
```bash
git clone git@github.com:codeshifu/eatly-react.git

cd eatly-react

npm install

npm start
```
Click the delete button on a menu in the list to delete

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#163503584](https://www.pivotaltracker.com/story/show/163503584)

#### Screenshots (if appropriate)
<img width="458" alt="screen shot 2019-01-27 at 7 51 09 pm" src="https://user-images.githubusercontent.com/5154605/51805393-eed10980-226c-11e9-8107-6dd9a229c31d.png">

#### Questions:
N/A
